### PR TITLE
Add static method to create fields

### DIFF
--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -112,4 +112,9 @@ abstract class Field
     {
         return $this->pivot;
     }
+
+    public static function create($name)
+    {
+        return new static($name);
+    }
 }


### PR DESCRIPTION
Now it's possible to create fields by calling the `create()` method:

```php
return [
    'title' => TextField::create('title')
        ->label('Nome da Árvore'),
    'type' => RadioField::create('type')
        ->label('Tipo de Árvore')
        ->options([
            'diagnosis' => 'Diagnóstico',
            'rootCause' => 'Causa raiz',
        ]),
    ...
];
```