### PR TITLE
Allow to use array in method multiple().

### DIFF
--- a/src/NavpiResource.php
+++ b/src/NavpiResource.php
@@ -228,8 +228,13 @@ abstract class NavpiResource extends JsonResource
                         if ($related_list instanceof Collection) {
                             $item[$name] = $related_list->pluck($multiple_relation_key);
                         } else {
-                            $item[$name] = $related_list->get([$multiple_relation_key])->pluck($multiple_relation_key);
+                            if (is_array($multiple_relation_key)) {
+                                $item[$name] = $related_list->get($multiple_relation_key);
+                            } else {
+                                $item[$name] = $related_list->get([$multiple_relation_key])->pluck($multiple_relation_key);
+                            }
                         }
+
                         continue;
                     }
                     if ($relation_key = $field->getRelationKey()) {


### PR DESCRIPTION
### Problema
Nos campos de upload só conseguimos exibir um único valor no **result**.
Ex: 
**Resource**
```php
'problem_photos' => Fields\UploadField::create('problem_photos')
                ->label('Fotos do problema')
                ->default([])
                ->multiple('url')
                ->entity('service-orders/problem-photos')
                ->extensions($this->allowImageExtensions())
                ->exceptActions([

                ]),
```
**Result**
```json
"problem_photos": [
    "http:\/\/www.link1.com.br",
    "http:\/\/www.link2.com.br"
]
```

### Solução
No método `multiple()` agora é possível passar um **array** de campos.
Ex:
**Resource**
```php
'problem_photos' => Fields\UploadField::create('problem_photos')
                ->label('Fotos do problema')
                ->default([])
                ->multiple([
                    'url as value',
                    'description as label',
                ])
                ->entity('service-orders/problem-photos')
                ->extensions($this->allowImageExtensions())
                ->exceptActions([

                ]),
```
**Result**
```json
"problem_photos": [
    {
         "value": "http:\/\/www.link2.com.br",
	 "label": "lorem ipsum foto 2"
    },
    {
         "value": "http:\/\/www.link1.com.br",
	 "label": "lorem ipsum foto 1"
    }
]
```
