### PR TITLE
Adding Pivot model support

### DIFF
--- a/src/NavpiResource.php
+++ b/src/NavpiResource.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
+use \Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Collection;
@@ -195,6 +196,15 @@ abstract class NavpiResource extends JsonResource
                             if (!is_null($resource->pivot) && in_array($pivot, array_keys($resource->pivot->attributesToArray()))) {
                                 $item[$name] = $resource->pivot->$pivot;
                             }
+                            if ($resource->pivot instanceof Pivot) {
+                                $item[$name] = $resource->pivot->$pivot;
+                                if (str_contains($pivot, '.')) {
+                                    $pivotName = explode('.', $pivot);
+                                    $pivotRelation = $pivotName[0];
+                                    $pivotValue = $pivotName[1];
+                                    $item[$name] = $resource->pivot->$pivotRelation->$pivotValue;
+                                }
+                            }
                             continue;
                         }
                         if ($field->getType() == 'function') {
@@ -250,6 +260,15 @@ abstract class NavpiResource extends JsonResource
                     if ($pivot = $field->getPivot()) {
                         if (!is_null($resource->pivot) && in_array($pivot, array_keys($resource->pivot->attributesToArray()))) {
                             $item[$name] = $resource->pivot->$pivot;
+                        }
+                        if ($resource->pivot instanceof Pivot) {
+                            $item[$name] = $resource->pivot->$pivot;
+                            if (str_contains($pivot, '.')) {
+                                $pivotName = explode('.', $pivot);
+                                $pivotRelation = $pivotName[0];
+                                $pivotValue = $pivotName[1];
+                                $item[$name] = $resource->pivot->$pivotRelation->$pivotValue;
+                            }
                         }
                         continue;
                     }


### PR DESCRIPTION
Esse PR aborda um relacionamento entre pivot em tabelas many to many.

Exemplo clássico para pegar valor do pivot
```php
'created_at' => (new Fields\DateField('created_at'))
    ->label('Data do vínculo')
    ->pivot('created_at'),
```

Agora podemos utilizar relacionamentos dentro do campo pivot e acessar seus atributos de uma forma simples.

```php
'position' => (new Fields\TextField('position'))
    ->label('Cargo')
    ->pivot('position.name'),
```

Lembrando que precisamos criar um model do tipo `Illuminate\Database\Eloquent\Relations\Pivot` em nosso relacionamento para funcionar.

Exemplo de utilização de um relacionamento com esse model Pivot:

```php
public function linked_companies(): BelongsToMany
{
    return $this->belongsToMany(Company::class, 'user_companies')
        ->using(UserCompany::class)
        ->withPivot('position_id')
        ->withTimestamps();
}
```

Para saber mais aqui esta a documentação 

https://laravel.com/docs/10.x/eloquent-relationships#defining-custom-intermediate-table-models